### PR TITLE
CORS Prefix Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ fetchMetagame({ year: "2019", month: "01" }, { name: "gen7ou" })
 
 ```
 
-## Browser Usage
+## Adding a Proxy
 
-This library is still usable in the browser, but will need slight modifications due to CORS issues. The last argument of the fetch functions will let you pass in a prefix to the base URL, giving you the option of using a CORS proxy. 
+This library is still usable in the browser, but may need slight modifications (for example, a CORS proxy for CORS issues). The last argument of the fetch functions will let you set a custom base URL, giving you the option of using a proxy of your choosing. 
 
-**Important:** Keep in mind that this approach is only as stable as the CORS proxy is. That means that you should expect downtime with this method, depending on your proxy of choice.
+**Important:** Keep in mind that this approach is only as stable as the proxy is. That means that you should expect downtime with this method, depending on your proxy of choice.
 
 ```typescript
 

--- a/README.md
+++ b/README.md
@@ -72,3 +72,41 @@ fetchMetagame({ year: "2019", month: "01" }, { name: "gen7ou" })
 
 
 ```
+
+## Browser Usage
+
+This library is still usable in the browser, but will need slight modifications due to CORS issues. The last argument of the fetch functions will let you pass in a prefix to the base URL, giving you the option of using a CORS proxy. 
+
+**Important:** Keep in mind that this approach is only as stable as the CORS proxy is. That means that you should expect downtime with this method, depending on your proxy of choice.
+
+```typescript
+
+// The cors.io proxy is used in these examples, but
+// you can use any proxy you like.
+
+fetchTimeframes("https://cors.io/?")
+    .then(timeframes => console.log("TIMEFRAMES", timeframes))
+    .catch(console.error);
+
+fetchFormats({ year: "2019", month: "01" }, true, "https://cors.io/?")
+    .then(formats => console.log("FORMATS MONO", formats))
+    .catch(console.error);
+
+fetchUsage({ year: "2019", month: "01" }, { name: "gen7ou" }, "https://cors.io/?")
+    .then(usage => console.log("USAGE", usage))
+    .catch(console.error);
+
+fetchChaos({ year: "2019", month: "01" }, { name: "gen7ou" }, "https://cors.io/?")
+    .then(chaos => console.log("CHAOS", chaos))
+    .catch(console.error);
+
+fetchLeads({ year: "2019", month: "01" }, { name: "gen7ou" }, "https://cors.io/?")
+    .then(leads => console.log("LEADS", leads))
+    .catch(console.error);
+
+fetchMetagame({ year: "2019", month: "01" }, { name: "gen7ou" }, "https://cors.io/?")
+    .then(meta => console.log("META", meta))
+    .catch(console.error);
+
+
+```

--- a/dist/smogon-usage-fetch.common.js
+++ b/dist/smogon-usage-fetch.common.js
@@ -262,16 +262,23 @@ class UrlBuilder {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Object containing chaos data.
  */
-const fetchChaos = async (timeframe, format) => fetch(new UrlBuilder()
-    .setSubFolder("chaos" /* CHAOS */)
-    .setExtension("json" /* JSON */)
-    .setTimeframe(timeframe)
-    .setFormat(format)
-    .build())
-    .then(checkStatus)
-    .then(res => res.json());
+const fetchChaos = async (timeframe, format, corsUrl) => {
+    const urlBuilder = new UrlBuilder();
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+    return fetch(urlBuilder
+        .setSubFolder("chaos" /* CHAOS */)
+        .setExtension("json" /* JSON */)
+        .setTimeframe(timeframe)
+        .setFormat(format)
+        .build())
+        .then(checkStatus)
+        .then(res => res.json());
+};
 
 /**
  * Removes trailing sequences from a string.
@@ -357,13 +364,17 @@ const parseFormatsPage = (html) => mapFormats(parseApacheDirectoryListing(html)
  * @public
  * @param timeframe Timeframe to load.
  * @param useMonotype Optional, If monotype formats should be loaded instead of "normal" formats, defaults to false.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return List of formats.
  */
-const fetchFormats = async (timeframe, useMonotype = false) => {
+const fetchFormats = async (timeframe, useMonotype = false, corsUrl) => {
     const urlBuilder = new UrlBuilder();
     urlBuilder.setTimeframe(timeframe);
     if (useMonotype) {
         urlBuilder.setSubFolder("monotype" /* MONOTYPE */);
+    }
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
     }
     return fetch(urlBuilder.build())
         .then(checkStatus)
@@ -553,17 +564,24 @@ const parseLeadsPage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Leads data.
  */
-const fetchLeads = async (timeframe, format) => fetch(new UrlBuilder()
-    .setSubFolder("leads" /* LEADS */)
-    .setExtension("txt" /* TEXT */)
-    .setTimeframe(timeframe)
-    .setFormat(format)
-    .build())
-    .then(checkStatus)
-    .then(res => res.text())
-    .then(parseLeadsPage);
+const fetchLeads = async (timeframe, format, corsUrl) => {
+    const urlBuilder = new UrlBuilder();
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+    return fetch(urlBuilder
+        .setSubFolder("leads" /* LEADS */)
+        .setExtension("txt" /* TEXT */)
+        .setTimeframe(timeframe)
+        .setFormat(format)
+        .build())
+        .then(checkStatus)
+        .then(res => res.text())
+        .then(parseLeadsPage);
+};
 
 const STALLINESS_MEAN_REGEX = / Stalliness \(mean: (-?[\d.]+)/;
 const STALLINESS_ONE_REGEX = / one # = {2}(-?[\d.]+%)/;
@@ -598,17 +616,24 @@ const parseMetagamePage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Metagame data.
  */
-const fetchMetagame = async (timeframe, format) => fetch(new UrlBuilder()
-    .setSubFolder("metagame" /* METAGAME */)
-    .setExtension("txt" /* TEXT */)
-    .setTimeframe(timeframe)
-    .setFormat(format)
-    .build())
-    .then(checkStatus)
-    .then(res => res.text())
-    .then(parseMetagamePage);
+const fetchMetagame = async (timeframe, format, corsUrl) => {
+    const urlBuilder = new UrlBuilder();
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+    return fetch(urlBuilder
+        .setSubFolder("metagame" /* METAGAME */)
+        .setExtension("txt" /* TEXT */)
+        .setTimeframe(timeframe)
+        .setFormat(format)
+        .build())
+        .then(checkStatus)
+        .then(res => res.text())
+        .then(parseMetagamePage);
+};
 
 /**
  * Loads moveset data for the given timeframe and format.
@@ -618,6 +643,7 @@ const fetchMetagame = async (timeframe, format) => fetch(new UrlBuilder()
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Moveset data.
  */
 const fetchMoveset = fetchChaos;
@@ -635,12 +661,19 @@ const parseTimeframesPage = (html) => mapTimeframes(parseApacheDirectoryListing(
  * Loads a list of all available timeframes.
  *
  * @public
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return List of timeframe names.
  */
-const fetchTimeframes = async () => fetch(new UrlBuilder().build())
-    .then(checkStatus)
-    .then(res => res.text())
-    .then(parseTimeframesPage);
+const fetchTimeframes = async (corsUrl) => {
+    const urlBuilder = new UrlBuilder();
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+    return fetch(urlBuilder.build())
+        .then(checkStatus)
+        .then(res => res.text())
+        .then(parseTimeframesPage);
+};
 
 const USAGE_TOTAL_ROW_INDEX = 0;
 const USAGE_WEIGHT_ROW_INDEX = 1;
@@ -690,16 +723,23 @@ const parseUsagePage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Usage data.
  */
-const fetchUsage = async (timeframe, format) => fetch(new UrlBuilder()
-    .setExtension("txt" /* TEXT */)
-    .setTimeframe(timeframe)
-    .setFormat(format)
-    .build())
-    .then(checkStatus)
-    .then(res => res.text())
-    .then(parseUsagePage);
+const fetchUsage = async (timeframe, format, corsUrl) => {
+    const urlBuilder = new UrlBuilder();
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+    return fetch(urlBuilder
+        .setExtension("txt" /* TEXT */)
+        .setTimeframe(timeframe)
+        .setFormat(format)
+        .build())
+        .then(checkStatus)
+        .then(res => res.text())
+        .then(parseUsagePage);
+};
 
 exports.createCombinedFormats = createCombinedFormats;
 exports.createCombinedTimeframes = createCombinedTimeframes;

--- a/dist/smogon-usage-fetch.common.js
+++ b/dist/smogon-usage-fetch.common.js
@@ -205,6 +205,10 @@ const URL_STATS = urlJoin(URL_BASE, URL_PATH_STATS);
  * @class
  */
 class UrlBuilder {
+    setCors(corsUrl) {
+        this.corsUrl = corsUrl;
+        return this;
+    }
     setSubFolder(subFolder) {
         this.subFolder = subFolder;
         return this;
@@ -229,6 +233,9 @@ class UrlBuilder {
      */
     build() {
         let folderUrl = URL_STATS;
+        if (!lightdash.isNil(this.corsUrl)) {
+            folderUrl = urlJoin(this.corsUrl, folderUrl);
+        }
         if (!lightdash.isNil(this.timeframe)) {
             folderUrl = urlJoin(folderUrl, joinTimeframeDataLine(this.timeframe));
         }

--- a/dist/smogon-usage-fetch.common.js
+++ b/dist/smogon-usage-fetch.common.js
@@ -234,7 +234,9 @@ class UrlBuilder {
     build() {
         let folderUrl = URL_STATS;
         if (!lightdash.isNil(this.corsUrl)) {
-            folderUrl = urlJoin(this.corsUrl, folderUrl);
+            // We use string addition instead of urlJoin
+            // to give more flexibility over how one wants to prefix
+            folderUrl = this.corsUrl + folderUrl;
         }
         if (!lightdash.isNil(this.timeframe)) {
             folderUrl = urlJoin(folderUrl, joinTimeframeDataLine(this.timeframe));

--- a/dist/smogon-usage-fetch.common.js
+++ b/dist/smogon-usage-fetch.common.js
@@ -196,7 +196,7 @@ const checkStatus = (res) => {
 
 const URL_BASE = "https://www.smogon.com";
 const URL_PATH_STATS = "stats";
-const URL_STATS = urlJoin(URL_BASE, URL_PATH_STATS);
+const DEFAULT_BASE_URL = urlJoin(URL_BASE, URL_PATH_STATS);
 
 /**
  * Builder for smogon stat URLs.
@@ -205,8 +205,8 @@ const URL_STATS = urlJoin(URL_BASE, URL_PATH_STATS);
  * @class
  */
 class UrlBuilder {
-    setCors(corsUrl) {
-        this.corsUrl = corsUrl;
+    setCustomBaseUrl(customBaseUrl) {
+        this.customBaseUrl = customBaseUrl;
         return this;
     }
     setSubFolder(subFolder) {
@@ -232,11 +232,11 @@ class UrlBuilder {
      * @return Built URL.
      */
     build() {
-        let folderUrl = URL_STATS;
-        if (!lightdash.isNil(this.corsUrl)) {
+        let folderUrl = DEFAULT_BASE_URL;
+        if (!lightdash.isNil(this.customBaseUrl)) {
             // We use string addition instead of urlJoin
             // to give more flexibility over how one wants to prefix
-            folderUrl = this.corsUrl + folderUrl;
+            folderUrl = this.customBaseUrl + folderUrl;
         }
         if (!lightdash.isNil(this.timeframe)) {
             folderUrl = urlJoin(folderUrl, joinTimeframeDataLine(this.timeframe));
@@ -264,13 +264,13 @@ class UrlBuilder {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Object containing chaos data.
  */
-const fetchChaos = async (timeframe, format, corsUrl) => {
+const fetchChaos = async (timeframe, format, customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder
         .setSubFolder("chaos" /* CHAOS */)
@@ -366,17 +366,17 @@ const parseFormatsPage = (html) => mapFormats(parseApacheDirectoryListing(html)
  * @public
  * @param timeframe Timeframe to load.
  * @param useMonotype Optional, If monotype formats should be loaded instead of "normal" formats, defaults to false.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return List of formats.
  */
-const fetchFormats = async (timeframe, useMonotype = false, corsUrl) => {
+const fetchFormats = async (timeframe, useMonotype = false, customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
     urlBuilder.setTimeframe(timeframe);
     if (useMonotype) {
         urlBuilder.setSubFolder("monotype" /* MONOTYPE */);
     }
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder.build())
         .then(checkStatus)
@@ -566,13 +566,13 @@ const parseLeadsPage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Leads data.
  */
-const fetchLeads = async (timeframe, format, corsUrl) => {
+const fetchLeads = async (timeframe, format, customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder
         .setSubFolder("leads" /* LEADS */)
@@ -618,13 +618,13 @@ const parseMetagamePage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Metagame data.
  */
-const fetchMetagame = async (timeframe, format, corsUrl) => {
+const fetchMetagame = async (timeframe, format, customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder
         .setSubFolder("metagame" /* METAGAME */)
@@ -645,7 +645,7 @@ const fetchMetagame = async (timeframe, format, corsUrl) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Moveset data.
  */
 const fetchMoveset = fetchChaos;
@@ -663,13 +663,13 @@ const parseTimeframesPage = (html) => mapTimeframes(parseApacheDirectoryListing(
  * Loads a list of all available timeframes.
  *
  * @public
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return List of timeframe names.
  */
-const fetchTimeframes = async (corsUrl) => {
+const fetchTimeframes = async (customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder.build())
         .then(checkStatus)
@@ -725,13 +725,13 @@ const parseUsagePage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Usage data.
  */
-const fetchUsage = async (timeframe, format, corsUrl) => {
+const fetchUsage = async (timeframe, format, customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder
         .setExtension("txt" /* TEXT */)

--- a/dist/smogon-usage-fetch.esm.js
+++ b/dist/smogon-usage-fetch.esm.js
@@ -256,16 +256,23 @@ class UrlBuilder {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Object containing chaos data.
  */
-const fetchChaos = async (timeframe, format) => fetch(new UrlBuilder()
-    .setSubFolder("chaos" /* CHAOS */)
-    .setExtension("json" /* JSON */)
-    .setTimeframe(timeframe)
-    .setFormat(format)
-    .build())
-    .then(checkStatus)
-    .then(res => res.json());
+const fetchChaos = async (timeframe, format, corsUrl) => {
+    const urlBuilder = new UrlBuilder();
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+    return fetch(urlBuilder
+        .setSubFolder("chaos" /* CHAOS */)
+        .setExtension("json" /* JSON */)
+        .setTimeframe(timeframe)
+        .setFormat(format)
+        .build())
+        .then(checkStatus)
+        .then(res => res.json());
+};
 
 /**
  * Removes trailing sequences from a string.
@@ -351,13 +358,17 @@ const parseFormatsPage = (html) => mapFormats(parseApacheDirectoryListing(html)
  * @public
  * @param timeframe Timeframe to load.
  * @param useMonotype Optional, If monotype formats should be loaded instead of "normal" formats, defaults to false.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return List of formats.
  */
-const fetchFormats = async (timeframe, useMonotype = false) => {
+const fetchFormats = async (timeframe, useMonotype = false, corsUrl) => {
     const urlBuilder = new UrlBuilder();
     urlBuilder.setTimeframe(timeframe);
     if (useMonotype) {
         urlBuilder.setSubFolder("monotype" /* MONOTYPE */);
+    }
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
     }
     return fetch(urlBuilder.build())
         .then(checkStatus)
@@ -547,17 +558,24 @@ const parseLeadsPage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Leads data.
  */
-const fetchLeads = async (timeframe, format) => fetch(new UrlBuilder()
-    .setSubFolder("leads" /* LEADS */)
-    .setExtension("txt" /* TEXT */)
-    .setTimeframe(timeframe)
-    .setFormat(format)
-    .build())
-    .then(checkStatus)
-    .then(res => res.text())
-    .then(parseLeadsPage);
+const fetchLeads = async (timeframe, format, corsUrl) => {
+    const urlBuilder = new UrlBuilder();
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+    return fetch(urlBuilder
+        .setSubFolder("leads" /* LEADS */)
+        .setExtension("txt" /* TEXT */)
+        .setTimeframe(timeframe)
+        .setFormat(format)
+        .build())
+        .then(checkStatus)
+        .then(res => res.text())
+        .then(parseLeadsPage);
+};
 
 const STALLINESS_MEAN_REGEX = / Stalliness \(mean: (-?[\d.]+)/;
 const STALLINESS_ONE_REGEX = / one # = {2}(-?[\d.]+%)/;
@@ -592,17 +610,24 @@ const parseMetagamePage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Metagame data.
  */
-const fetchMetagame = async (timeframe, format) => fetch(new UrlBuilder()
-    .setSubFolder("metagame" /* METAGAME */)
-    .setExtension("txt" /* TEXT */)
-    .setTimeframe(timeframe)
-    .setFormat(format)
-    .build())
-    .then(checkStatus)
-    .then(res => res.text())
-    .then(parseMetagamePage);
+const fetchMetagame = async (timeframe, format, corsUrl) => {
+    const urlBuilder = new UrlBuilder();
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+    return fetch(urlBuilder
+        .setSubFolder("metagame" /* METAGAME */)
+        .setExtension("txt" /* TEXT */)
+        .setTimeframe(timeframe)
+        .setFormat(format)
+        .build())
+        .then(checkStatus)
+        .then(res => res.text())
+        .then(parseMetagamePage);
+};
 
 /**
  * Loads moveset data for the given timeframe and format.
@@ -612,6 +637,7 @@ const fetchMetagame = async (timeframe, format) => fetch(new UrlBuilder()
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Moveset data.
  */
 const fetchMoveset = fetchChaos;
@@ -629,12 +655,19 @@ const parseTimeframesPage = (html) => mapTimeframes(parseApacheDirectoryListing(
  * Loads a list of all available timeframes.
  *
  * @public
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return List of timeframe names.
  */
-const fetchTimeframes = async () => fetch(new UrlBuilder().build())
-    .then(checkStatus)
-    .then(res => res.text())
-    .then(parseTimeframesPage);
+const fetchTimeframes = async (corsUrl) => {
+    const urlBuilder = new UrlBuilder();
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+    return fetch(urlBuilder.build())
+        .then(checkStatus)
+        .then(res => res.text())
+        .then(parseTimeframesPage);
+};
 
 const USAGE_TOTAL_ROW_INDEX = 0;
 const USAGE_WEIGHT_ROW_INDEX = 1;
@@ -684,15 +717,22 @@ const parseUsagePage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Usage data.
  */
-const fetchUsage = async (timeframe, format) => fetch(new UrlBuilder()
-    .setExtension("txt" /* TEXT */)
-    .setTimeframe(timeframe)
-    .setFormat(format)
-    .build())
-    .then(checkStatus)
-    .then(res => res.text())
-    .then(parseUsagePage);
+const fetchUsage = async (timeframe, format, corsUrl) => {
+    const urlBuilder = new UrlBuilder();
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+    return fetch(urlBuilder
+        .setExtension("txt" /* TEXT */)
+        .setTimeframe(timeframe)
+        .setFormat(format)
+        .build())
+        .then(checkStatus)
+        .then(res => res.text())
+        .then(parseUsagePage);
+};
 
 export { createCombinedFormats, createCombinedTimeframes, fetchChaos, fetchFormats, fetchLeads, fetchMetagame, fetchMoveset, fetchTimeframes, fetchUsage, joinFormatDataLine, joinTimeframeDataLine, splitFormatDataLine, splitTimeframeDataLine };

--- a/dist/smogon-usage-fetch.esm.js
+++ b/dist/smogon-usage-fetch.esm.js
@@ -190,7 +190,7 @@ const checkStatus = (res) => {
 
 const URL_BASE = "https://www.smogon.com";
 const URL_PATH_STATS = "stats";
-const URL_STATS = urlJoin(URL_BASE, URL_PATH_STATS);
+const DEFAULT_BASE_URL = urlJoin(URL_BASE, URL_PATH_STATS);
 
 /**
  * Builder for smogon stat URLs.
@@ -199,8 +199,8 @@ const URL_STATS = urlJoin(URL_BASE, URL_PATH_STATS);
  * @class
  */
 class UrlBuilder {
-    setCors(corsUrl) {
-        this.corsUrl = corsUrl;
+    setCustomBaseUrl(customBaseUrl) {
+        this.customBaseUrl = customBaseUrl;
         return this;
     }
     setSubFolder(subFolder) {
@@ -226,11 +226,11 @@ class UrlBuilder {
      * @return Built URL.
      */
     build() {
-        let folderUrl = URL_STATS;
-        if (!isNil(this.corsUrl)) {
+        let folderUrl = DEFAULT_BASE_URL;
+        if (!isNil(this.customBaseUrl)) {
             // We use string addition instead of urlJoin
             // to give more flexibility over how one wants to prefix
-            folderUrl = this.corsUrl + folderUrl;
+            folderUrl = this.customBaseUrl + folderUrl;
         }
         if (!isNil(this.timeframe)) {
             folderUrl = urlJoin(folderUrl, joinTimeframeDataLine(this.timeframe));
@@ -258,13 +258,13 @@ class UrlBuilder {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Object containing chaos data.
  */
-const fetchChaos = async (timeframe, format, corsUrl) => {
+const fetchChaos = async (timeframe, format, customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder
         .setSubFolder("chaos" /* CHAOS */)
@@ -360,17 +360,17 @@ const parseFormatsPage = (html) => mapFormats(parseApacheDirectoryListing(html)
  * @public
  * @param timeframe Timeframe to load.
  * @param useMonotype Optional, If monotype formats should be loaded instead of "normal" formats, defaults to false.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return List of formats.
  */
-const fetchFormats = async (timeframe, useMonotype = false, corsUrl) => {
+const fetchFormats = async (timeframe, useMonotype = false, customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
     urlBuilder.setTimeframe(timeframe);
     if (useMonotype) {
         urlBuilder.setSubFolder("monotype" /* MONOTYPE */);
     }
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder.build())
         .then(checkStatus)
@@ -560,13 +560,13 @@ const parseLeadsPage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Leads data.
  */
-const fetchLeads = async (timeframe, format, corsUrl) => {
+const fetchLeads = async (timeframe, format, customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder
         .setSubFolder("leads" /* LEADS */)
@@ -612,13 +612,13 @@ const parseMetagamePage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Metagame data.
  */
-const fetchMetagame = async (timeframe, format, corsUrl) => {
+const fetchMetagame = async (timeframe, format, customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder
         .setSubFolder("metagame" /* METAGAME */)
@@ -639,7 +639,7 @@ const fetchMetagame = async (timeframe, format, corsUrl) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Moveset data.
  */
 const fetchMoveset = fetchChaos;
@@ -657,13 +657,13 @@ const parseTimeframesPage = (html) => mapTimeframes(parseApacheDirectoryListing(
  * Loads a list of all available timeframes.
  *
  * @public
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return List of timeframe names.
  */
-const fetchTimeframes = async (corsUrl) => {
+const fetchTimeframes = async (customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder.build())
         .then(checkStatus)
@@ -719,13 +719,13 @@ const parseUsagePage = (page) => {
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Usage data.
  */
-const fetchUsage = async (timeframe, format, corsUrl) => {
+const fetchUsage = async (timeframe, format, customBaseUrl) => {
     const urlBuilder = new UrlBuilder();
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
     return fetch(urlBuilder
         .setExtension("txt" /* TEXT */)

--- a/dist/smogon-usage-fetch.esm.js
+++ b/dist/smogon-usage-fetch.esm.js
@@ -199,6 +199,10 @@ const URL_STATS = urlJoin(URL_BASE, URL_PATH_STATS);
  * @class
  */
 class UrlBuilder {
+    setCors(corsUrl) {
+        this.corsUrl = corsUrl;
+        return this;
+    }
     setSubFolder(subFolder) {
         this.subFolder = subFolder;
         return this;
@@ -223,6 +227,9 @@ class UrlBuilder {
      */
     build() {
         let folderUrl = URL_STATS;
+        if (!isNil(this.corsUrl)) {
+            folderUrl = urlJoin(this.corsUrl, folderUrl);
+        }
         if (!isNil(this.timeframe)) {
             folderUrl = urlJoin(folderUrl, joinTimeframeDataLine(this.timeframe));
         }

--- a/dist/smogon-usage-fetch.esm.js
+++ b/dist/smogon-usage-fetch.esm.js
@@ -228,7 +228,9 @@ class UrlBuilder {
     build() {
         let folderUrl = URL_STATS;
         if (!isNil(this.corsUrl)) {
-            folderUrl = urlJoin(this.corsUrl, folderUrl);
+            // We use string addition instead of urlJoin
+            // to give more flexibility over how one wants to prefix
+            folderUrl = this.corsUrl + folderUrl;
         }
         if (!isNil(this.timeframe)) {
             folderUrl = urlJoin(folderUrl, joinTimeframeDataLine(this.timeframe));

--- a/docs/smogon-usage-fetch.esm.js.html
+++ b/docs/smogon-usage-fetch.esm.js.html
@@ -233,7 +233,7 @@ const checkStatus = (res) => {
 
 const URL_BASE = "https://www.smogon.com";
 const URL_PATH_STATS = "stats";
-const URL_STATS = urlJoin(URL_BASE, URL_PATH_STATS);
+const DEFAULT_BASE_URL = urlJoin(URL_BASE, URL_PATH_STATS);
 
 /**
  * Builder for smogon stat URLs.
@@ -265,7 +265,7 @@ class UrlBuilder {
      * @return Built URL.
      */
     build() {
-        let folderUrl = URL_STATS;
+        let folderUrl = DEFAULT_BASE_URL;
         if (!isNil(this.timeframe)) {
             folderUrl = urlJoin(folderUrl, joinTimeframeDataLine(this.timeframe));
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,12 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@babel/parser": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+            "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+            "dev": true
+        },
         "@types/cheerio": {
             "version": "0.22.11",
             "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.11.tgz",
@@ -144,12 +150,6 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
-        "babylon": {
-            "version": "7.0.0-beta.19",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-            "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-            "dev": true
-        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -212,9 +212,9 @@
             }
         },
         "bluebird": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-            "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
             "dev": true
         },
         "boolbase": {
@@ -285,12 +285,12 @@
             }
         },
         "catharsis": {
-            "version": "0.8.9",
-            "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
-            "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+            "version": "0.8.10",
+            "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.10.tgz",
+            "integrity": "sha512-l2OUaz/3PU3MZylspVFJvwHCVfWyvcduPq4lv3AzZ2pJzZCo7kNKFNyatwujD7XgvGkNAE/Jhhbh2uARNwNkfw==",
             "dev": true,
             "requires": {
-                "underscore-contrib": "~0.3.0"
+                "lodash": "^4.17.11"
             }
         },
         "chalk": {
@@ -1083,32 +1083,42 @@
             }
         },
         "js2xmlparser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
-            "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz",
+            "integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
             "dev": true,
             "requires": {
-                "xmlcreate": "^1.0.1"
+                "xmlcreate": "^2.0.0"
             }
         },
         "jsdoc": {
-            "version": "3.5.5",
-            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
-            "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.2.tgz",
+            "integrity": "sha512-S2vzg99C5+gb7FWlrK4TVdyzVPGGkdvpDkCEJH1JABi2PKzPeLu5/zZffcJUifgWUJqXWl41Hoc+MmuM2GukIg==",
             "dev": true,
             "requires": {
-                "babylon": "7.0.0-beta.19",
-                "bluebird": "~3.5.0",
-                "catharsis": "~0.8.9",
-                "escape-string-regexp": "~1.0.5",
-                "js2xmlparser": "~3.0.0",
-                "klaw": "~2.0.0",
-                "marked": "~0.3.6",
-                "mkdirp": "~0.5.1",
-                "requizzle": "~0.2.1",
-                "strip-json-comments": "~2.0.1",
+                "@babel/parser": "^7.4.4",
+                "bluebird": "^3.5.4",
+                "catharsis": "^0.8.10",
+                "escape-string-regexp": "^2.0.0",
+                "js2xmlparser": "^4.0.0",
+                "klaw": "^3.0.0",
+                "markdown-it": "^8.4.2",
+                "markdown-it-anchor": "^5.0.2",
+                "marked": "^0.6.2",
+                "mkdirp": "^0.5.1",
+                "requizzle": "^0.2.2",
+                "strip-json-comments": "^3.0.1",
                 "taffydb": "2.6.2",
-                "underscore": "~1.8.3"
+                "underscore": "~1.9.1"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+                    "dev": true
+                }
             }
         },
         "json-parse-better-errors": {
@@ -1139,9 +1149,9 @@
             "dev": true
         },
         "klaw": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
-            "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+            "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.9"
@@ -1151,6 +1161,15 @@
             "version": "10.2.2",
             "resolved": "https://registry.npmjs.org/lightdash/-/lightdash-10.2.2.tgz",
             "integrity": "sha512-ctlvP3IztWvcbA5QdYMv59fOEU/OGKBHIUyZSYL8jHP74focTk2yJlUlxtaqw9ZVrBWbuhHD2zQwr+VBC7Cuhg=="
+        },
+        "linkify-it": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
+            "integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
+            "dev": true,
+            "requires": {
+                "uc.micro": "^1.0.1"
+            }
         },
         "load-json-file": {
             "version": "4.0.0",
@@ -1184,10 +1203,35 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "markdown-it": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+            "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "entities": "~1.1.1",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            }
+        },
+        "markdown-it-anchor": {
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz",
+            "integrity": "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A==",
+            "dev": true
+        },
         "marked": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-            "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
+            "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==",
+            "dev": true
+        },
+        "mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
             "dev": true
         },
         "memorystream": {
@@ -1518,20 +1562,12 @@
             "dev": true
         },
         "requizzle": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
-            "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.2.tgz",
+            "integrity": "sha512-oJ6y7JcUJkblRGhMByGNcszeLgU0qDxNKFCiUZR1XyzHyVsev+Mxb1tyygxLd1ORsKee1SA5BInFdUwY64GE/A==",
             "dev": true,
             "requires": {
-                "underscore": "~1.6.0"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.6.0",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-                    "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-                    "dev": true
-                }
+                "lodash": "^4.17.11"
             }
         },
         "resolve": {
@@ -1904,9 +1940,9 @@
             "dev": true
         },
         "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+            "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
             "dev": true
         },
         "supports-color": {
@@ -2016,28 +2052,17 @@
             "integrity": "sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==",
             "dev": true
         },
-        "underscore": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+        "uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
             "dev": true
         },
-        "underscore-contrib": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
-            "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
-            "dev": true,
-            "requires": {
-                "underscore": "1.6.0"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.6.0",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-                    "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-                    "dev": true
-                }
-            }
+        "underscore": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+            "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+            "dev": true
         },
         "union-value": {
             "version": "1.0.0",
@@ -2163,9 +2188,9 @@
             "dev": true
         },
         "xmlcreate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-            "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
+            "integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "@types/jasmine": "^3.3.12",
         "docdash": "^1.1.0",
         "jasmine": "^3.4.0",
-        "jsdoc": "^3.5.5",
+        "jsdoc": "^3.6.2",
         "npm-run-all": "^4.1.5",
         "prettier": "^1.17.0",
         "rollup": "^1.10.1",

--- a/src/fetch/chaos.ts
+++ b/src/fetch/chaos.ts
@@ -19,7 +19,7 @@ import { checkStatus } from "../util/httpUtil";
 const fetchChaos = async (
     timeframe: ITimeframeData,
     format: IFormatData,
-    customBaseUrl: string
+    customBaseUrl?: string
 ): Promise<IChaosData> => {
     const urlBuilder = new UrlBuilder();
 

--- a/src/fetch/chaos.ts
+++ b/src/fetch/chaos.ts
@@ -13,14 +13,22 @@ import { checkStatus } from "../util/httpUtil";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Object containing chaos data.
  */
 const fetchChaos = async (
     timeframe: ITimeframeData,
-    format: IFormatData
-): Promise<IChaosData> =>
-    fetch(
-        new UrlBuilder()
+    format: IFormatData,
+    corsUrl: string
+): Promise<IChaosData> => {
+    const urlBuilder = new UrlBuilder();
+
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+
+    return fetch(
+        urlBuilder
             .setSubFolder(SubFolder.CHAOS)
             .setExtension(Extension.JSON)
             .setTimeframe(timeframe)
@@ -29,5 +37,6 @@ const fetchChaos = async (
     )
         .then(checkStatus)
         .then(res => res.json());
+}
 
 export { fetchChaos };

--- a/src/fetch/chaos.ts
+++ b/src/fetch/chaos.ts
@@ -13,18 +13,18 @@ import { checkStatus } from "../util/httpUtil";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Object containing chaos data.
  */
 const fetchChaos = async (
     timeframe: ITimeframeData,
     format: IFormatData,
-    corsUrl: string
+    customBaseUrl: string
 ): Promise<IChaosData> => {
     const urlBuilder = new UrlBuilder();
 
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
 
     return fetch(

--- a/src/fetch/formats.ts
+++ b/src/fetch/formats.ts
@@ -18,7 +18,7 @@ import { checkStatus } from "../util/httpUtil";
 const fetchFormats = async (
     timeframe: ITimeframeData,
     useMonotype: boolean = false,
-    customBaseUrl: string
+    customBaseUrl?: string
 ): Promise<IFormatsData> => {
     const urlBuilder = new UrlBuilder();
     urlBuilder.setTimeframe(timeframe);

--- a/src/fetch/formats.ts
+++ b/src/fetch/formats.ts
@@ -12,13 +12,13 @@ import { checkStatus } from "../util/httpUtil";
  * @public
  * @param timeframe Timeframe to load.
  * @param useMonotype Optional, If monotype formats should be loaded instead of "normal" formats, defaults to false.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return List of formats.
  */
 const fetchFormats = async (
     timeframe: ITimeframeData,
     useMonotype: boolean = false,
-    corsUrl: string
+    customBaseUrl: string
 ): Promise<IFormatsData> => {
     const urlBuilder = new UrlBuilder();
     urlBuilder.setTimeframe(timeframe);
@@ -27,8 +27,8 @@ const fetchFormats = async (
         urlBuilder.setSubFolder(SubFolder.MONOTYPE);
     }
 
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
 
     return fetch(urlBuilder.build())

--- a/src/fetch/formats.ts
+++ b/src/fetch/formats.ts
@@ -12,17 +12,23 @@ import { checkStatus } from "../util/httpUtil";
  * @public
  * @param timeframe Timeframe to load.
  * @param useMonotype Optional, If monotype formats should be loaded instead of "normal" formats, defaults to false.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return List of formats.
  */
 const fetchFormats = async (
     timeframe: ITimeframeData,
-    useMonotype: boolean = false
+    useMonotype: boolean = false,
+    corsUrl: string
 ): Promise<IFormatsData> => {
     const urlBuilder = new UrlBuilder();
     urlBuilder.setTimeframe(timeframe);
 
     if (useMonotype) {
         urlBuilder.setSubFolder(SubFolder.MONOTYPE);
+    }
+
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
     }
 
     return fetch(urlBuilder.build())

--- a/src/fetch/leads.ts
+++ b/src/fetch/leads.ts
@@ -13,18 +13,18 @@ import { checkStatus } from "../util/httpUtil";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Leads data.
  */
 const fetchLeads = async (
     timeframe: ITimeframeData,
     format: IFormatData,
-    corsUrl: string
+    customBaseUrl: string
 ): Promise<ILeadsData> => {
     const urlBuilder = new UrlBuilder();
 
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
 
     return fetch(

--- a/src/fetch/leads.ts
+++ b/src/fetch/leads.ts
@@ -13,14 +13,22 @@ import { checkStatus } from "../util/httpUtil";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Leads data.
  */
 const fetchLeads = async (
     timeframe: ITimeframeData,
-    format: IFormatData
-): Promise<ILeadsData> =>
-    fetch(
-        new UrlBuilder()
+    format: IFormatData,
+    corsUrl: string
+): Promise<ILeadsData> => {
+    const urlBuilder = new UrlBuilder();
+
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+
+    return fetch(
+        urlBuilder
             .setSubFolder(SubFolder.LEADS)
             .setExtension(Extension.TEXT)
             .setTimeframe(timeframe)
@@ -30,5 +38,6 @@ const fetchLeads = async (
         .then(checkStatus)
         .then(res => res.text())
         .then(parseLeadsPage);
+}
 
 export { fetchLeads };

--- a/src/fetch/leads.ts
+++ b/src/fetch/leads.ts
@@ -19,7 +19,7 @@ import { checkStatus } from "../util/httpUtil";
 const fetchLeads = async (
     timeframe: ITimeframeData,
     format: IFormatData,
-    customBaseUrl: string
+    customBaseUrl?: string
 ): Promise<ILeadsData> => {
     const urlBuilder = new UrlBuilder();
 

--- a/src/fetch/metagame.ts
+++ b/src/fetch/metagame.ts
@@ -22,7 +22,7 @@ import { checkStatus } from "../util/httpUtil";
 const fetchMetagame = async (
     timeframe: ITimeframeData,
     format: IFormatData,
-    customBaseUrl: string
+    customBaseUrl?: string
 ): Promise<IMetagameData> => {
     const urlBuilder = new UrlBuilder();
 

--- a/src/fetch/metagame.ts
+++ b/src/fetch/metagame.ts
@@ -16,14 +16,22 @@ import { checkStatus } from "../util/httpUtil";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Metagame data.
  */
 const fetchMetagame = async (
     timeframe: ITimeframeData,
-    format: IFormatData
-): Promise<IMetagameData> =>
-    fetch(
-        new UrlBuilder()
+    format: IFormatData,
+    corsUrl: string
+): Promise<IMetagameData> => {
+    const urlBuilder = new UrlBuilder();
+
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+
+    return fetch(
+        urlBuilder
             .setSubFolder(SubFolder.METAGAME)
             .setExtension(Extension.TEXT)
             .setTimeframe(timeframe)
@@ -33,5 +41,6 @@ const fetchMetagame = async (
         .then(checkStatus)
         .then(res => res.text())
         .then(parseMetagamePage);
+}
 
 export { fetchMetagame };

--- a/src/fetch/metagame.ts
+++ b/src/fetch/metagame.ts
@@ -16,18 +16,18 @@ import { checkStatus } from "../util/httpUtil";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Metagame data.
  */
 const fetchMetagame = async (
     timeframe: ITimeframeData,
     format: IFormatData,
-    corsUrl: string
+    customBaseUrl: string
 ): Promise<IMetagameData> => {
     const urlBuilder = new UrlBuilder();
 
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
 
     return fetch(

--- a/src/fetch/moveset.ts
+++ b/src/fetch/moveset.ts
@@ -8,6 +8,7 @@ import { fetchChaos } from "./chaos";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Moveset data.
  */
 const fetchMoveset = fetchChaos;

--- a/src/fetch/moveset.ts
+++ b/src/fetch/moveset.ts
@@ -8,7 +8,7 @@ import { fetchChaos } from "./chaos";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Moveset data.
  */
 const fetchMoveset = fetchChaos;

--- a/src/fetch/timeframes.ts
+++ b/src/fetch/timeframes.ts
@@ -8,12 +8,20 @@ import { checkStatus } from "../util/httpUtil";
  * Loads a list of all available timeframes.
  *
  * @public
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return List of timeframe names.
  */
-const fetchTimeframes = async (): Promise<ITimeframesData> =>
-    fetch(new UrlBuilder().build())
+const fetchTimeframes = async (corsUrl: string): Promise<ITimeframesData> => {
+    const urlBuilder = new UrlBuilder();
+
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+
+    return fetch(urlBuilder.build())
         .then(checkStatus)
         .then(res => res.text())
         .then(parseTimeframesPage);
+}
 
 export { fetchTimeframes };

--- a/src/fetch/timeframes.ts
+++ b/src/fetch/timeframes.ts
@@ -8,14 +8,14 @@ import { checkStatus } from "../util/httpUtil";
  * Loads a list of all available timeframes.
  *
  * @public
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return List of timeframe names.
  */
-const fetchTimeframes = async (corsUrl: string): Promise<ITimeframesData> => {
+const fetchTimeframes = async (customBaseUrl: string): Promise<ITimeframesData> => {
     const urlBuilder = new UrlBuilder();
 
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
 
     return fetch(urlBuilder.build())

--- a/src/fetch/timeframes.ts
+++ b/src/fetch/timeframes.ts
@@ -11,7 +11,7 @@ import { checkStatus } from "../util/httpUtil";
  * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return List of timeframe names.
  */
-const fetchTimeframes = async (customBaseUrl: string): Promise<ITimeframesData> => {
+const fetchTimeframes = async (customBaseUrl?: string): Promise<ITimeframesData> => {
     const urlBuilder = new UrlBuilder();
 
     if (customBaseUrl) {

--- a/src/fetch/usage.ts
+++ b/src/fetch/usage.ts
@@ -12,14 +12,22 @@ import { checkStatus } from "../util/httpUtil";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Usage data.
  */
 const fetchUsage = async (
     timeframe: ITimeframeData,
-    format: IFormatData
-): Promise<IUsageData> =>
-    fetch(
-        new UrlBuilder()
+    format: IFormatData,
+    corsUrl: string
+): Promise<IUsageData> => {
+    const urlBuilder = new UrlBuilder();
+
+    if (corsUrl) {
+        urlBuilder.setCors(corsUrl);
+    }
+
+    return fetch(
+        urlBuilder
             .setExtension(Extension.TEXT)
             .setTimeframe(timeframe)
             .setFormat(format)
@@ -28,5 +36,6 @@ const fetchUsage = async (
         .then(checkStatus)
         .then(res => res.text())
         .then(parseUsagePage);
+}
 
 export { fetchUsage };

--- a/src/fetch/usage.ts
+++ b/src/fetch/usage.ts
@@ -12,18 +12,18 @@ import { checkStatus } from "../util/httpUtil";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Usage data.
  */
 const fetchUsage = async (
     timeframe: ITimeframeData,
     format: IFormatData,
-    corsUrl: string
+    customBaseUrl: string
 ): Promise<IUsageData> => {
     const urlBuilder = new UrlBuilder();
 
-    if (corsUrl) {
-        urlBuilder.setCors(corsUrl);
+    if (customBaseUrl) {
+        urlBuilder.setCustomBaseUrl(customBaseUrl);
     }
 
     return fetch(

--- a/src/fetch/usage.ts
+++ b/src/fetch/usage.ts
@@ -18,7 +18,7 @@ import { checkStatus } from "../util/httpUtil";
 const fetchUsage = async (
     timeframe: ITimeframeData,
     format: IFormatData,
-    customBaseUrl: string
+    customBaseUrl?: string
 ): Promise<IUsageData> => {
     const urlBuilder = new UrlBuilder();
 

--- a/src/url/UrlBuilder.ts
+++ b/src/url/UrlBuilder.ts
@@ -7,7 +7,7 @@ import {
 import { urlJoin } from "../util/httpUtil";
 import { Extension } from "./Extension";
 import { SubFolder } from "./SubFolder";
-import { URL_STATS } from "./urlBase";
+import { DEFAULT_BASE_URL } from "./urlBase";
 
 /**
  * Builder for smogon stat URLs.
@@ -16,14 +16,14 @@ import { URL_STATS } from "./urlBase";
  * @class
  */
 class UrlBuilder {
-    private corsUrl?: string;
+    private customBaseUrl?: string;
     private subFolder?: SubFolder;
     private extension?: Extension;
     private timeframe?: ITimeframeData;
     private format?: IFormatData;
 
-    public setCors(corsUrl: string): UrlBuilder {
-        this.corsUrl = corsUrl;
+    public setCustomBaseUrl(customBaseUrl: string): UrlBuilder {
+        this.customBaseUrl = customBaseUrl;
         return this;
     }
 
@@ -54,11 +54,11 @@ class UrlBuilder {
      * @return Built URL.
      */
     public build(): string {
-        let folderUrl = URL_STATS;
-        if (!isNil(this.corsUrl)) {
+        let folderUrl = DEFAULT_BASE_URL;
+        if (!isNil(this.customBaseUrl)) {
             // We use string addition instead of urlJoin
             // to give more flexibility over how one wants to prefix
-            folderUrl = this.corsUrl + folderUrl;
+            folderUrl = this.customBaseUrl + folderUrl;
         }
         if (!isNil(this.timeframe)) {
             folderUrl = urlJoin(

--- a/src/url/UrlBuilder.ts
+++ b/src/url/UrlBuilder.ts
@@ -56,7 +56,9 @@ class UrlBuilder {
     public build(): string {
         let folderUrl = URL_STATS;
         if (!isNil(this.corsUrl)) {
-            folderUrl = urlJoin(this.corsUrl, folderUrl);
+            // We use string addition instead of urlJoin
+            // to give more flexibility over how one wants to prefix
+            folderUrl = this.corsUrl + folderUrl;
         }
         if (!isNil(this.timeframe)) {
             folderUrl = urlJoin(

--- a/src/url/UrlBuilder.ts
+++ b/src/url/UrlBuilder.ts
@@ -16,10 +16,16 @@ import { URL_STATS } from "./urlBase";
  * @class
  */
 class UrlBuilder {
+    private corsUrl?: string;
     private subFolder?: SubFolder;
     private extension?: Extension;
     private timeframe?: ITimeframeData;
     private format?: IFormatData;
+
+    public setCors(corsUrl: string): UrlBuilder {
+        this.corsUrl = corsUrl;
+        return this;
+    }
 
     public setSubFolder(subFolder: SubFolder): UrlBuilder {
         this.subFolder = subFolder;
@@ -49,6 +55,9 @@ class UrlBuilder {
      */
     public build(): string {
         let folderUrl = URL_STATS;
+        if (!isNil(this.corsUrl)) {
+            folderUrl = urlJoin(this.corsUrl, folderUrl);
+        }
         if (!isNil(this.timeframe)) {
             folderUrl = urlJoin(
                 folderUrl,

--- a/src/url/urlBase.ts
+++ b/src/url/urlBase.ts
@@ -2,6 +2,6 @@ import { urlJoin } from "../util/httpUtil";
 
 const URL_BASE = "https://www.smogon.com";
 const URL_PATH_STATS = "stats";
-const URL_STATS = urlJoin(URL_BASE, URL_PATH_STATS);
+const DEFAULT_BASE_URL = urlJoin(URL_BASE, URL_PATH_STATS);
 
-export { URL_BASE, URL_PATH_STATS, URL_STATS };
+export { URL_BASE, URL_PATH_STATS, DEFAULT_BASE_URL };

--- a/types/fetch/chaos.d.ts
+++ b/types/fetch/chaos.d.ts
@@ -7,7 +7,8 @@ import { ITimeframeData } from "../parse/smogon/timeframe";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Object containing chaos data.
  */
-declare const fetchChaos: (timeframe: ITimeframeData, format: IFormatData) => Promise<IChaosData>;
+declare const fetchChaos: (timeframe: ITimeframeData, format: IFormatData, corsUrl?: string) => Promise<IChaosData>;
 export { fetchChaos };

--- a/types/fetch/chaos.d.ts
+++ b/types/fetch/chaos.d.ts
@@ -7,8 +7,8 @@ import { ITimeframeData } from "../parse/smogon/timeframe";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Object containing chaos data.
  */
-declare const fetchChaos: (timeframe: ITimeframeData, format: IFormatData, corsUrl?: string) => Promise<IChaosData>;
+declare const fetchChaos: (timeframe: ITimeframeData, format: IFormatData, customBaseUrl?: string) => Promise<IChaosData>;
 export { fetchChaos };

--- a/types/fetch/formats.d.ts
+++ b/types/fetch/formats.d.ts
@@ -6,8 +6,8 @@ import { ITimeframeData } from "../parse/smogon/timeframe";
  * @public
  * @param timeframe Timeframe to load.
  * @param useMonotype Optional, If monotype formats should be loaded instead of "normal" formats, defaults to false.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return List of formats.
  */
-declare const fetchFormats: (timeframe: ITimeframeData, useMonotype?: boolean, corsUrl?: string) => Promise<IFormatsData>;
+declare const fetchFormats: (timeframe: ITimeframeData, useMonotype?: boolean, customBaseUrl?: string) => Promise<IFormatsData>;
 export { fetchFormats };

--- a/types/fetch/formats.d.ts
+++ b/types/fetch/formats.d.ts
@@ -6,7 +6,8 @@ import { ITimeframeData } from "../parse/smogon/timeframe";
  * @public
  * @param timeframe Timeframe to load.
  * @param useMonotype Optional, If monotype formats should be loaded instead of "normal" formats, defaults to false.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return List of formats.
  */
-declare const fetchFormats: (timeframe: ITimeframeData, useMonotype?: boolean) => Promise<IFormatsData>;
+declare const fetchFormats: (timeframe: ITimeframeData, useMonotype?: boolean, corsUrl?: string) => Promise<IFormatsData>;
 export { fetchFormats };

--- a/types/fetch/leads.d.ts
+++ b/types/fetch/leads.d.ts
@@ -7,7 +7,8 @@ import { ITimeframeData } from "../parse/smogon/timeframe";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Leads data.
  */
-declare const fetchLeads: (timeframe: ITimeframeData, format: IFormatData) => Promise<ILeadsData>;
+declare const fetchLeads: (timeframe: ITimeframeData, format: IFormatData, corsUrl?: string) => Promise<ILeadsData>;
 export { fetchLeads };

--- a/types/fetch/leads.d.ts
+++ b/types/fetch/leads.d.ts
@@ -7,8 +7,8 @@ import { ITimeframeData } from "../parse/smogon/timeframe";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Leads data.
  */
-declare const fetchLeads: (timeframe: ITimeframeData, format: IFormatData, corsUrl?: string) => Promise<ILeadsData>;
+declare const fetchLeads: (timeframe: ITimeframeData, format: IFormatData, customBaseUrl?: string) => Promise<ILeadsData>;
 export { fetchLeads };

--- a/types/fetch/metagame.d.ts
+++ b/types/fetch/metagame.d.ts
@@ -7,8 +7,8 @@ import { ITimeframeData } from "../parse/smogon/timeframe";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Metagame data.
  */
-declare const fetchMetagame: (timeframe: ITimeframeData, format: IFormatData, corsUrl?: string) => Promise<IMetagameData>;
+declare const fetchMetagame: (timeframe: ITimeframeData, format: IFormatData, customBaseUrl?: string) => Promise<IMetagameData>;
 export { fetchMetagame };

--- a/types/fetch/metagame.d.ts
+++ b/types/fetch/metagame.d.ts
@@ -7,7 +7,8 @@ import { ITimeframeData } from "../parse/smogon/timeframe";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Metagame data.
  */
-declare const fetchMetagame: (timeframe: ITimeframeData, format: IFormatData) => Promise<IMetagameData>;
+declare const fetchMetagame: (timeframe: ITimeframeData, format: IFormatData, corsUrl?: string) => Promise<IMetagameData>;
 export { fetchMetagame };

--- a/types/fetch/moveset.d.ts
+++ b/types/fetch/moveset.d.ts
@@ -6,7 +6,8 @@
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Moveset data.
  */
-declare const fetchMoveset: (timeframe: import("../parse/smogon/timeframe").ITimeframeData, format: import("../parse/smogon/format").IFormatData) => Promise<import("../parse/smogon/page/chaos").IChaosData>;
+declare const fetchMoveset: (timeframe: import("../parse/smogon/timeframe").ITimeframeData, format: import("../parse/smogon/format").IFormatData, corsUrl?: string) => Promise<import("../parse/smogon/page/chaos").IChaosData>;
 export { fetchMoveset };

--- a/types/fetch/moveset.d.ts
+++ b/types/fetch/moveset.d.ts
@@ -6,8 +6,8 @@
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Moveset data.
  */
-declare const fetchMoveset: (timeframe: import("../parse/smogon/timeframe").ITimeframeData, format: import("../parse/smogon/format").IFormatData, corsUrl?: string) => Promise<import("../parse/smogon/page/chaos").IChaosData>;
+declare const fetchMoveset: (timeframe: import("../parse/smogon/timeframe").ITimeframeData, format: import("../parse/smogon/format").IFormatData, customBaseUrl?: string) => Promise<import("../parse/smogon/page/chaos").IChaosData>;
 export { fetchMoveset };

--- a/types/fetch/timeframes.d.ts
+++ b/types/fetch/timeframes.d.ts
@@ -3,7 +3,8 @@ import { ITimeframesData } from "../parse/smogon/timeframe";
  * Loads a list of all available timeframes.
  *
  * @public
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return List of timeframe names.
  */
-declare const fetchTimeframes: () => Promise<ITimeframesData>;
+declare const fetchTimeframes: (corsUrl?: string) => Promise<ITimeframesData>;
 export { fetchTimeframes };

--- a/types/fetch/timeframes.d.ts
+++ b/types/fetch/timeframes.d.ts
@@ -3,8 +3,8 @@ import { ITimeframesData } from "../parse/smogon/timeframe";
  * Loads a list of all available timeframes.
  *
  * @public
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return List of timeframe names.
  */
-declare const fetchTimeframes: (corsUrl?: string) => Promise<ITimeframesData>;
+declare const fetchTimeframes: (customBaseUrl?: string) => Promise<ITimeframesData>;
 export { fetchTimeframes };

--- a/types/fetch/usage.d.ts
+++ b/types/fetch/usage.d.ts
@@ -7,8 +7,8 @@ import { ITimeframeData } from "../parse/smogon/timeframe";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
- * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
+ * @param customBaseUrl Optional, prefixes the fetched URL with this base URL
  * @return Usage data.
  */
-declare const fetchUsage: (timeframe: ITimeframeData, format: IFormatData, corsUrl?: string) => Promise<IUsageData>;
+declare const fetchUsage: (timeframe: ITimeframeData, format: IFormatData, customBaseUrl?: string) => Promise<IUsageData>;
 export { fetchUsage };

--- a/types/fetch/usage.d.ts
+++ b/types/fetch/usage.d.ts
@@ -7,7 +7,8 @@ import { ITimeframeData } from "../parse/smogon/timeframe";
  * @public
  * @param timeframe Timeframe to load.
  * @param format Format to load.
+ * @param corsUrl Optional, uses given CORS proxy to bypass CORS problems in the browser
  * @return Usage data.
  */
-declare const fetchUsage: (timeframe: ITimeframeData, format: IFormatData) => Promise<IUsageData>;
+declare const fetchUsage: (timeframe: ITimeframeData, format: IFormatData, corsUrl?: string) => Promise<IUsageData>;
 export { fetchUsage };

--- a/types/url/UrlBuilder.d.ts
+++ b/types/url/UrlBuilder.d.ts
@@ -9,12 +9,12 @@ import { SubFolder } from "./SubFolder";
  * @class
  */
 declare class UrlBuilder {
-    private corsUrl?;
+    private customBaseUrl?;
     private subFolder?;
     private extension?;
     private timeframe?;
     private format?;
-    setCors(corsUrl: string): UrlBuilder;
+    setCustomBaseUrl(customBaseUrl: string): UrlBuilder;
     setSubFolder(subFolder: SubFolder): UrlBuilder;
     setExtension(extension: Extension): UrlBuilder;
     setTimeframe(timeframe: ITimeframeData): UrlBuilder;

--- a/types/url/UrlBuilder.d.ts
+++ b/types/url/UrlBuilder.d.ts
@@ -9,10 +9,12 @@ import { SubFolder } from "./SubFolder";
  * @class
  */
 declare class UrlBuilder {
+    private corsUrl?;
     private subFolder?;
     private extension?;
     private timeframe?;
     private format?;
+    setCors(corsUrl: string): UrlBuilder;
     setSubFolder(subFolder: SubFolder): UrlBuilder;
     setExtension(extension: Extension): UrlBuilder;
     setTimeframe(timeframe: ITimeframeData): UrlBuilder;

--- a/types/url/urlBase.d.ts
+++ b/types/url/urlBase.d.ts
@@ -1,4 +1,4 @@
 declare const URL_BASE = "https://www.smogon.com";
 declare const URL_PATH_STATS = "stats";
-declare const URL_STATS: string;
-export { URL_BASE, URL_PATH_STATS, URL_STATS };
+declare const DEFAULT_BASE_URL: string;
+export { URL_BASE, URL_PATH_STATS, DEFAULT_BASE_URL };


### PR DESCRIPTION
Using this library in the browser normally results in CORS issues when attempting to fetch data. This feature attempts to provide a workaround by allowing the user to prefix the URL with a CORS proxy of their choice.

I modified the URL builder to account for a corsUrl variable, and the fetch functions to take in the corsUrl as their last argument.